### PR TITLE
fix: buffer/integration fixes (Task 7)

### DIFF
--- a/docs/decisions/001-adapter-strategy.md
+++ b/docs/decisions/001-adapter-strategy.md
@@ -94,3 +94,15 @@ with no API key needed.
 - LLM provider coverage is effectively unlimited via LiteLLM without any adapter code.
 - `litellm` is added as a dependency in `pyproject.toml`.
 - STT/TTS provider fields use `Literal` for early validation; LLM provider uses `str`.
+
+### Note: InterviewConfig is intentionally not an adapter
+
+`InterviewConfig` fields (`type`, `difficulty`, `persona`) also use `Literal` but for a
+different reason — they are not plugin points. Adding a new interview type (e.g.
+`"case_study"`) requires coordinated changes across the question bank, scoring logic,
+and engine prompts. The `Literal` makes that coupling explicit: a contributor cannot
+add `"case_study"` to the config without the compiler/validator forcing them to
+acknowledge the other required changes.
+
+This is distinct from STT/TTS where a new provider is self-contained in one adapter
+file. Do not apply the adapter pattern to `InterviewConfig`.

--- a/interviewd/config.py
+++ b/interviewd/config.py
@@ -63,6 +63,8 @@ class Settings(BaseSettings):
     model_config = SettingsConfigDict(
         env_prefix="INTERVIEWD_",
         env_nested_delimiter="__",
+        env_file=".env",
+        env_file_encoding="utf-8",
     )
 
     stt: STTConfig = STTConfig()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ dependencies = [
     "instructor>=1.4",
     "sqlalchemy>=2.0",
     "litellm>=1.40",
+    "python-dotenv>=1.0",
     "soundfile>=0.12",
 ]
 

--- a/tests/adapters/test_stt.py
+++ b/tests/adapters/test_stt.py
@@ -54,17 +54,12 @@ async def test_groq_transcribe():
 async def test_whisper_local_transcribe():
     """Whisper local adapter should call whisper.transcribe and return stripped text."""
     config = STTConfig(provider="whisper_local", model="base")
+    adapter = get_stt_adapter(config)
 
+    # Only mock run_in_executor — this prevents the real (blocking) whisper model
+    # from loading while letting real tempfile creation/deletion run normally.
     with patch("interviewd.adapters.stt.whisper_local.asyncio.get_event_loop") as mock_loop:
-        mock_loop.return_value.run_in_executor = AsyncMock(
-            return_value={"text": "  Hello world.  "}
-        )
-        with patch("builtins.open", MagicMock()):
-            with patch("interviewd.adapters.stt.whisper_local.tempfile.NamedTemporaryFile") as mock_tmp:
-                mock_tmp.return_value.__enter__ = MagicMock(return_value=MagicMock(name="f"))
-                mock_tmp.return_value.__exit__ = MagicMock(return_value=False)
-                with patch("interviewd.adapters.stt.whisper_local.Path.unlink"):
-                    adapter = get_stt_adapter(config)
-                    result = await adapter.transcribe(b"fake-audio-bytes")
+        mock_loop.return_value.run_in_executor = AsyncMock(return_value={"text": "  Hello world.  "})
+        result = await adapter.transcribe(b"fake-audio-bytes")
 
     assert result == "Hello world."


### PR DESCRIPTION
## Summary

- **`.env` support** — `Settings` now loads a `.env` file automatically via pydantic-settings `env_file`. Users can set `GROQ_API_KEY=...` in a `.env` file instead of exporting shell variables. Added `python-dotenv>=1.0` dependency.
- **Simplified `whisper_local` test** — reduced from 4 nested patches (`NamedTemporaryFile`, `Path.unlink`, `builtins.open`, `get_event_loop`) down to 1. Real tempfile creation/deletion runs normally; only `run_in_executor` is mocked to prevent the whisper model from loading in CI.
- **`InterviewConfig` coupling documented** — ADR 001 now explains why `InterviewConfig` uses `Literal` for a fundamentally different reason than STT/TTS adapters, and explicitly flags that the adapter pattern should not be applied to it.

## Test plan

- [ ] `uv run pytest tests/ -v` — 29 tests, all passing
- [ ] Create a `.env` file with `GROQ_API_KEY=...` and confirm `load_settings()` picks it up without any shell exports

🤖 Generated with [Claude Code](https://claude.com/claude-code)