### PR TITLE
feat: technical, hr, and system_design question banks (Task 13)

### DIFF
--- a/config/questions/hr.yaml
+++ b/config/questions/hr.yaml
@@ -1,0 +1,86 @@
+questions:
+  # --- entry ---
+
+  - id: hr001
+    text: "Where do you see yourself professionally in three years and how does this role fit that path?"
+    tags: [career_growth, self_awareness]
+    difficulty: entry
+    follow_up: "What would tell you after six months that this was the right move?"
+
+  - id: hr002
+    text: "How do you handle feedback that you strongly disagree with?"
+    tags: [feedback, resilience, self_awareness]
+    difficulty: entry
+    follow_up: "Describe a specific piece of feedback that changed how you work, even if it was uncomfortable."
+
+  - id: hr003
+    text: "Describe a time you had to collaborate closely with someone whose working style was very different from yours."
+    tags: [collaboration, adaptability]
+    difficulty: entry
+    follow_up: "What did you learn about your own working style from that experience?"
+
+  # --- mid ---
+
+  - id: hr004
+    text: "How do you manage your workload when you have more work than time and every stakeholder says their priority is highest?"
+    tags: [prioritisation, stakeholder_management, time_management]
+    difficulty: mid
+    follow_up: "Tell me about a time you had to push back on a request that felt urgent but wasn't the right priority."
+
+  - id: hr005
+    text: "Describe how you have helped onboard a new team member — what worked, what didn't, and what you would do differently."
+    tags: [onboarding, mentoring, teamwork]
+    difficulty: mid
+    follow_up: "How do you know when onboarding has genuinely succeeded rather than just completed?"
+
+  - id: hr006
+    text: "Tell me about a time you gave difficult feedback to a peer. How did you approach it and what happened?"
+    tags: [feedback, communication, courage]
+    difficulty: mid
+    follow_up: "What would you do differently if the relationship had been more strained to begin with?"
+
+  - id: hr007
+    text: "How do you build trust with stakeholders who are sceptical of your team's ability to deliver?"
+    tags: [stakeholder_management, trust, communication]
+    difficulty: mid
+    follow_up: "Describe a situation where you won over a sceptical stakeholder. What specifically turned it around?"
+
+  # --- senior ---
+
+  - id: hr008
+    text: "How have you contributed to or redesigned a hiring process to consistently attract and assess strong candidates?"
+    tags: [hiring, process_design]
+    difficulty: senior
+    follow_up: "What's the biggest mistake you've seen in technical or domain-specific hiring, and how did you fix it?"
+
+  - id: hr009
+    text: "Describe how you create psychological safety on your team — specifically in situations where raising problems carries perceived risk."
+    tags: [psychological_safety, leadership, culture]
+    difficulty: senior
+    follow_up: "Tell me about a time psychological safety broke down. What caused it and how did you recover it?"
+
+  - id: hr010
+    text: "How do you develop high-performing team members who have no interest in moving into management?"
+    tags: [career_development, mentoring, retention]
+    difficulty: senior
+    follow_up: "What signals tell you someone is being stretched appropriately versus being under-challenged?"
+
+  - id: hr011
+    text: "Describe a time you had to manage a team through significant organisational uncertainty — a reorg, layoffs, or a major strategy shift."
+    tags: [change_management, leadership, resilience]
+    difficulty: senior
+    follow_up: "How did you balance transparency with the team against information you weren't yet able to share?"
+
+  # --- staff ---
+
+  - id: hr012
+    text: "How have you driven a meaningful culture change across an organisation — not just within your immediate team?"
+    tags: [culture, influence, strategy]
+    difficulty: staff
+    follow_up: "How did you measure whether the change actually stuck?"
+
+  - id: hr013
+    text: "Describe how you align multiple teams around a strategy they were initially resistant to or confused by."
+    tags: [alignment, strategy, communication]
+    difficulty: staff
+    follow_up: "What's the difference between alignment you've genuinely achieved and compliance you've mistaken for alignment?"

--- a/config/questions/system_design.yaml
+++ b/config/questions/system_design.yaml
@@ -1,0 +1,66 @@
+questions:
+  # --- mid ---
+
+  - id: sd001
+    text: "Design a system to collect, store, and query audit logs for a regulated application that must retain records for seven years."
+    tags: [storage, compliance, observability]
+    difficulty: mid
+    follow_up: "How would your design change if the query latency SLA dropped from minutes to seconds?"
+
+  - id: sd002
+    text: "How would you design an idempotent API layer for a payment or claims-processing service where duplicate requests must never cause double-processing?"
+    tags: [idempotency, reliability, distributed_systems]
+    difficulty: mid
+    follow_up: "Where does your approach break down at very high throughput, and how would you address that?"
+
+  - id: sd003
+    text: "Walk me through how you would design a feature flag system that supports gradual rollouts, A/B testing, and instant kill-switches."
+    tags: [rollout, risk_management, observability]
+    difficulty: mid
+    follow_up: "How would you make sure the system doesn't become a graveyard of flags nobody dares to clean up?"
+
+  # --- senior ---
+
+  - id: sd004
+    text: "Design a data pipeline that must be reliable, replayable, and fully observable — processing events from multiple upstream sources into a reporting store."
+    tags: [data_pipeline, reliability, observability]
+    difficulty: senior
+    follow_up: "How do you handle late-arriving data without reprocessing the entire history?"
+
+  - id: sd005
+    text: "How would you architect a multi-tenant platform where different tenants have different data residency and compliance requirements?"
+    tags: [multi_tenancy, compliance, architecture]
+    difficulty: senior
+    follow_up: "How does your design behave when a tenant's compliance requirements change after they are already onboarded?"
+
+  - id: sd006
+    text: "Design an event-driven system where producers emit at high throughput but downstream consumers process at wildly different speeds."
+    tags: [event_driven, backpressure, scalability]
+    difficulty: senior
+    follow_up: "How do you prevent a slow consumer from affecting the reliability of faster ones?"
+
+  - id: sd007
+    text: "How would you design the rollback and recovery strategy for a system that applies schema migrations to a large production database with no downtime window?"
+    tags: [migrations, reliability, zero_downtime]
+    difficulty: senior
+    follow_up: "What's the hardest class of migration to roll back, and how do you approach it?"
+
+  # --- staff ---
+
+  - id: sd008
+    text: "Walk me through how you would make an existing monolith incrementally more modular without a big-bang rewrite — while keeping the product shipping."
+    tags: [architecture, migration, risk_management]
+    difficulty: staff
+    follow_up: "How do you decide what to extract first and how do you measure progress?"
+
+  - id: sd009
+    text: "How would you design a platform that abstracts away the differences between cloud providers so engineering teams can deploy workloads portably?"
+    tags: [cloud, abstraction, platform_engineering]
+    difficulty: staff
+    follow_up: "What layer of the stack is hardest to abstract, and when does the abstraction cost more than it saves?"
+
+  - id: sd010
+    text: "Design a developer productivity platform — CI/CD, environments, observability tooling — for an organisation of 200 engineers across 15 teams."
+    tags: [developer_experience, platform_engineering, scaling]
+    difficulty: staff
+    follow_up: "How do you balance standardisation with the autonomy teams need to move fast in their domain?"

--- a/config/questions/technical.yaml
+++ b/config/questions/technical.yaml
@@ -1,0 +1,86 @@
+questions:
+  # --- entry ---
+
+  - id: t001
+    text: "Walk me through how you debug an issue in a system you've never seen before."
+    tags: [debugging, problem_solving]
+    difficulty: entry
+    follow_up: "What's the first signal you look for when you have no prior context?"
+
+  - id: t002
+    text: "How do you decide whether a bug is severe enough to block a release?"
+    tags: [quality, judgement]
+    difficulty: entry
+    follow_up: "Describe a time you pushed back on shipping something you felt wasn't ready."
+
+  - id: t003
+    text: "How do you stay current with fast-moving technology in your domain?"
+    tags: [learning, self_development]
+    difficulty: entry
+    follow_up: "What was the last thing you learned that changed how you approach your work?"
+
+  # --- mid ---
+
+  - id: t004
+    text: "Describe your approach to code review — what do you look for as both author and reviewer?"
+    tags: [code_quality, collaboration]
+    difficulty: mid
+    follow_up: "Tell me about a review where you had a real disagreement. How did it resolve?"
+
+  - id: t005
+    text: "How do you evaluate a third-party library or external tool before adopting it in production?"
+    tags: [decision_making, risk, tooling]
+    difficulty: mid
+    follow_up: "Walk me through a tool adoption that went well and one that didn't."
+
+  - id: t006
+    text: "Walk me through how you investigated and resolved a performance problem in a production system."
+    tags: [performance, debugging, production]
+    difficulty: mid
+    follow_up: "How did you verify the fix didn't introduce a regression elsewhere?"
+
+  - id: t007
+    text: "How do you approach writing tests — what makes a test suite valuable vs. a burden?"
+    tags: [testing, quality]
+    difficulty: mid
+    follow_up: "Describe the worst test suite you inherited and how you improved it."
+
+  # --- senior ---
+
+  - id: t008
+    text: "Describe a significant architectural trade-off you made. What did you weigh and what did you give up?"
+    tags: [architecture, trade_offs, decision_making]
+    difficulty: senior
+    follow_up: "Looking back, would you make the same call today? Why or why not?"
+
+  - id: t009
+    text: "How do you approach security in your day-to-day engineering work beyond the obvious checklist items?"
+    tags: [security, engineering_culture]
+    difficulty: senior
+    follow_up: "Tell me about a vulnerability or risk you identified that others had missed."
+
+  - id: t010
+    text: "How do you keep technical debt visible and actionable on a team moving fast?"
+    tags: [technical_debt, engineering_culture, prioritisation]
+    difficulty: senior
+    follow_up: "Describe a time you successfully got non-technical stakeholders to prioritise debt paydown."
+
+  - id: t011
+    text: "How do you mentor engineers who are technically strong but struggle to communicate or influence across teams?"
+    tags: [mentoring, communication, growth]
+    difficulty: senior
+    follow_up: "What signals tell you that coaching is working?"
+
+  # --- staff ---
+
+  - id: t012
+    text: "How do you set and enforce engineering standards across multiple teams without becoming a bottleneck?"
+    tags: [standards, scaling, influence]
+    difficulty: staff
+    follow_up: "How do you handle a team that consistently ignores the standards everyone else has adopted?"
+
+  - id: t013
+    text: "Describe how you have driven adoption of a new practice or technology across an organisation that was resistant to change."
+    tags: [change_management, influence, strategy]
+    difficulty: staff
+    follow_up: "What would you do differently if you were starting that effort today?"


### PR DESCRIPTION
## Summary

Adds three question banks that cover the shared themes across the target roles (AI engineering manager, blockchain lead developer, manual tester for insurance benefits). Banks are role-agnostic — interviewers compose the right type for each role:

| Bank | Questions | Levels | Representative topics |
|---|---|---|---|
| `technical.yaml` | 13 | entry–staff | Debugging, code review, tooling decisions, security, technical debt, mentoring, engineering standards |
| `hr.yaml` | 13 | entry–staff | Feedback, onboarding, prioritisation, stakeholder trust, hiring, psychological safety, career development, culture change |
| `system_design.yaml` | 10 | mid–staff | Audit logs/compliance, idempotency, feature flags, data pipelines, multi-tenancy, event-driven backpressure, zero-downtime migrations, monolith decomposition, cloud portability |

## Role → bank mapping
- **AI engineering manager** → `hr` + `system_design` (+ `behavioral` for soft skills)
- **Blockchain lead developer** → `technical` + `system_design`
- **Manual tester / insurance benefits** → `technical` + `hr`

## Notes
- `InterviewConfig.type` Literal already declared all four types — only the YAML files were missing
- `system_design` has no `entry`-level questions by design; the CLI exits cleanly with a helpful message if that combination is requested
- `QuestionBank.pick()` respects difficulty rank — a `mid` session never draws `senior`/`staff` questions

## Test plan
- [x] All three banks load and filter correctly across all difficulty levels (verified with smoke test)
- [x] 79/79 tests passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)