### PR TITLE
fix: improve setup reliability for Windows and fresh-clone onboarding

### DIFF
--- a/interviewd/cli/main.py
+++ b/interviewd/cli/main.py
@@ -74,21 +74,6 @@ def setup(
     run_setup(force=force, start=start)
 
 
-# ---------------------------------------------------------------------------
-# setup
-# ---------------------------------------------------------------------------
-
-
-@app.command()
-def setup(
-    force: bool = typer.Option(False, "--force", "-f", help="Re-configure keys that are already set"),
-    start: Optional[bool] = typer.Option(None, "--start/--no-start", help="Start dev server after setup"),
-) -> None:
-    """Configure API keys and optionally start the dev server. For a fresh clone, run bash setup.sh instead."""
-    from interviewd.cli.setup import run_setup
-    run_setup(force=force, start=start)
-
-
 def _version_callback(value: bool) -> None:
     if value:
         from importlib.metadata import version, PackageNotFoundError

--- a/interviewd/cli/setup.py
+++ b/interviewd/cli/setup.py
@@ -5,7 +5,16 @@ root instead — it installs uv, Python, Node.js, and all dependencies before
 calling this wizard.
 """
 import os
+import sys
 from pathlib import Path
+
+# Ensure box-drawing / emoji characters render correctly on Windows terminals
+# that default to cp1252.  No-op on macOS/Linux where utf-8 is the default.
+if sys.stdout.encoding and sys.stdout.encoding.lower() not in ("utf-8", "utf8"):
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[attr-defined]
+    except Exception:
+        pass
 
 import typer
 from dotenv import dotenv_values, set_key

--- a/interviewd/web/app.py
+++ b/interviewd/web/app.py
@@ -23,9 +23,14 @@ async def lifespan(app: FastAPI):
     server starts cleanly and surfaces missing-key errors as HTTP 503s rather than
     a crash at boot time.
     """
+    from dotenv import load_dotenv
     from interviewd.config import load_settings
     from interviewd.data.question_bank import QuestionBank
     from interviewd.store.session_store import SessionStore
+
+    # Load .env into os.environ so third-party clients (Groq, LiteLLM, etc.)
+    # that read directly from the environment can find their API keys.
+    load_dotenv(override=False)
 
     settings = load_settings()
     app.state.settings = settings

--- a/setup.sh
+++ b/setup.sh
@@ -67,12 +67,33 @@ fi
 step "[2/5] Python 3.11+"
 
 _py_ok() {
-    command -v python3 &>/dev/null || return 1
-    python3 -c "import sys; exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null
+    # Try python3 then python — handles macOS/Linux ('python3') and Windows Git
+    # Bash ('python').  The Windows App Execution Alias for python3 exists in
+    # PATH but errors at runtime, so we test both existence AND executability.
+    local py
+    for py in python3 python; do
+        if command -v "$py" &>/dev/null \
+           && "$py" -c "import sys; exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null; then
+            return 0
+        fi
+    done
+    return 1
+}
+
+_py_cmd() {
+    # Return whichever python command actually works on this system
+    local py
+    for py in python3 python; do
+        if command -v "$py" &>/dev/null \
+           && "$py" -c "import sys; exit(0 if sys.version_info >= (3,11) else 1)" 2>/dev/null; then
+            echo "$py"; return
+        fi
+    done
+    echo python  # fallback
 }
 
 if _py_ok; then
-    ok "Python $(python3 -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
+    ok "Python $($(_py_cmd) -c "import sys; print(f'{sys.version_info.major}.{sys.version_info.minor}')")"
 else
     fail "Python 3.11+ not found"
     info "uv can install and manage Python versions for you"
@@ -139,8 +160,8 @@ fi
 
 # ── Step 4: Python deps ───────────────────────────────────────────
 step "[4/5] Python dependencies"
-info "uv sync --extra web"
-uv sync --extra web
+info "uv sync --extra web --extra planner --extra dev"
+uv sync --extra web --extra planner --extra dev
 ok "Python deps ready"
 
 # ── Step 5: Frontend deps ─────────────────────────────────────────
@@ -160,5 +181,5 @@ if [[ "${CI:-}" == "true" ]]; then
     ok "CI environment — skipping interactive key setup"
     ok "All done. Run 'uv run interviewd setup' to configure API keys."
 else
-    uv run interviewd setup
+    PYTHONIOENCODING=utf-8 uv run interviewd setup
 fi


### PR DESCRIPTION
## Summary

- **Windows Python detection**: `setup.sh` now tries both `python3` and `python`, handling the MS Store App Execution Alias stub that exists in PATH but errors at runtime — prevents a false "Python 3.11+ not found" followed by a redundant uv download
- **Full extras sync**: `uv sync` now includes `--extra planner --extra dev` (was only `--extra web`), matching what the project actually requires
- **Windows terminal encoding**: `PYTHONIOENCODING=utf-8` added to the `interviewd setup` call in `setup.sh`; `cli/setup.py` also reconfigures stdout to UTF-8 at import time so box-drawing/emoji chars render correctly on Windows cp1252 terminals
- **Duplicate command removed**: accidental duplicate `setup` command registration in `cli/main.py` cleaned up
- **`.env` loading in web app**: `load_dotenv()` called in the FastAPI lifespan so API keys from `.env` are visible to third-party clients (Groq, LiteLLM) that read from `os.environ` directly

## Test plan

- [ ] Fresh clone on Windows (Git Bash): `bash setup.sh` should show `✓ Python 3.11` without downloading a redundant Python copy
- [ ] Fresh clone on macOS/Linux: `bash setup.sh` should behave identically to before
- [ ] `uv run interviewd setup` renders box-drawing characters correctly in Windows Terminal
- [ ] `uv run uvicorn interviewd.web.app:app` starts without crashing when `.env` contains API keys

🤖 Generated with [Claude Code](https://claude.com/claude-code)